### PR TITLE
Add Blogs I Like section and event-queue resource link

### DIFF
--- a/content/misc/Posts I Like.md
+++ b/content/misc/Posts I Like.md
@@ -5,6 +5,26 @@ date: 2026-05-29
 
 A running list of blog posts and articles I've enjoyed reading.
 
+## Blogs I Like
+
+Blogs (as opposed to single posts) that I like and follow via RSS or email.
+
+- [Melting Asphalt](https://meltingasphalt.com/archive/) — Kevin Simler
+- [Gwern.net](https://gwern.net/)
+- [Slate Star Codex](https://slatestarcodex.com/archives/)
+- [Michael Nielsen — Augmenting Long-term Memory](https://augmentingcognition.com/ltm) ([michaelnielsen.org](https://michaelnielsen.org/))
+- [Patrick Collison — Fast](https://patrickcollison.com/fast)
+- [guzey.com](https://guzey.com/)
+- [Justin Math](https://www.justinmath.com/you-have-to-work-really-hard-to-figure-out-what-fulfills-you/)
+- [ntietz](https://www.ntietz.com/blog/)
+- [kalzumeus](https://www.kalzumeus.com/2009/10/23/the-ie-css-bug-which-cost-me-a-months-salary/)
+
+### Magazines
+
+- [Alter Mag](https://altermag.com/)
+- [Commoncog — Asian Conglomerates](https://commoncog.com/c/concepts/asian-conglomerates/)
+- [Commoncog — Cases](https://commoncog.com/c/cases/)
+
 ---
 
 ### [By the Numbers](https://gwern.net/doc/philosophy/2010-richardson-bythenumbers-vectors30)

--- a/content/notes/LLD2.md
+++ b/content/notes/LLD2.md
@@ -4,6 +4,12 @@ date: 2025-09-01
 
 ---
 
+## Great Resources
+
+- [Game Programming Patterns — Event Queue](https://gameprogrammingpatterns.com/event-queue.html) — one of the clearest real-world pattern walkthroughs out there; the whole site is worth reading
+
+---
+
 # Gang of Four Design Patterns
 
 _LLMs were used to create this summary_


### PR DESCRIPTION
## Summary
- Add a "Blogs I Like" section (with a Magazines subsection) near the top of `content/misc/Posts I Like.md`, listing sites followed via RSS/email — distinct from the existing dated single-post entries below it.
- Add a link to Game Programming Patterns' [Event Queue](https://gameprogrammingpatterns.com/event-queue.html) chapter as a recommended resource near the top of `content/notes/LLD2.md` (Design Patterns).

## Test plan
- [x] Reviewed rendered markdown structure visually in the diff
- [ ] Spot-check on the live Quartz build after merge