### PR TITLE
Verify the 80% forgetting claim and plot the Ebbinghaus curve

### DIFF
--- a/content/notes/2026-26-06-Anki.md
+++ b/content/notes/2026-26-06-Anki.md
@@ -9,14 +9,41 @@ tags:
 
 ### Learning is memory++
 - To build novel ideas, you need to fetch the base ideas into working memory, operate on them, and then store the result. If the base ideas are not recalled, the novel idea cannot be formed.
-> [!quote]- On memorisation - skycak
-> Our claims of “learning is not memorization” may sound poetic in the abstract, but when asked to break them down concretely, we find our explanations start to sound more and more like “tower-building is not nailing wood, not welding steel, not balancing load, it is none of those mechanical things, it is the emergent grace of brushing the heavens.” Which is completely devoid of instructional value, and entirely unhelpful to any aspiring tower-builder, aside from possibly inspiring a fleeting spark of motivation that spends itself searching for a place to spend itself. - skycak
+> [!quote]- On memorisation
+> Our claims of “learning is not memorization” may sound poetic in the abstract, but when asked to break them down concretely, we find our explanations start to sound more and more like “tower-building is not nailing wood, not welding steel, not balancing load, it is none of those mechanical things, it is the emergent grace of brushing the heavens.” Which is completely devoid of instructional value, and entirely unhelpful to any aspiring tower-builder, aside from possibly inspiring a fleeting spark of motivation that spends itself searching for a place to spend itself. - Justin Skycak
 
 ### Memories decay
-- The probability of recalling something decays exponentially with time. 
-- Approximately, 80% of what you learn today will be forgotten by the next week. (is this number made up)
-- Ebbinghaus_forgetting_curves.jpg
+- The probability of recalling something decays with time — steeply at first, then flattening out.
+- Approximately, 80% of what you learn today will be forgotten by the next week. The number is not made up — it survives contact with its source, Ebbinghaus (1885), and with a modern replication. But it is a worst case rather than a constant, and worth reading with the caveats attached.
+
+<figure class="fc-fig"><style>.fc-fig{margin:1.4rem 0}.fc-fig svg{width:100%;height:auto;display:block}.fc-fig .grid{stroke:var(--lightgray);stroke-width:1}.fc-fig .tick,.fc-fig .lgd{fill:var(--darkgray);font-size:12.5px;font-family:inherit}.fc-fig .val{fill:var(--dark);font-size:12.5px;font-weight:600;font-family:inherit}.fc-fig .ln{fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round}.fc-fig .dot{stroke:var(--light);stroke-width:2}.fc-fig .ln.s1{stroke:#2a78d6}.fc-fig .dot.s1{fill:#2a78d6}.fc-fig .ln.s2{stroke:#eb6834}.fc-fig .dot.s2{fill:#eb6834}.fc-fig figcaption{font-size:.85em;color:var(--gray);margin-top:.5rem;line-height:1.5}:root[saved-theme=dark] .fc-fig .ln.s1{stroke:#3987e5}:root[saved-theme=dark] .fc-fig .dot.s1{fill:#3987e5}:root[saved-theme=dark] .fc-fig .ln.s2{stroke:#d95926}:root[saved-theme=dark] .fc-fig .dot.s2{fill:#d95926}</style><svg viewBox="0 0 660 388" role="img" aria-label="Forgetting curve: percentage of learning saved on relearning, from 20 minutes to 31 days. Ebbinghaus 1885 falls from 58% to 21%; the Murre and Dros 2015 replication falls from 47% to 4%."><line class="grid" x1="58" y1="300" x2="628" y2="300"/><line class="grid" x1="58" y1="208.7" x2="628" y2="208.7"/><line class="grid" x1="58" y1="117.3" x2="628" y2="117.3"/><line class="grid" x1="58" y1="26" x2="628" y2="26"/><text class="tick" x="48" y="304" text-anchor="end">0%</text><text class="tick" x="48" y="212.7" text-anchor="end">20%</text><text class="tick" x="48" y="121.3" text-anchor="end">40%</text><text class="tick" x="48" y="30" text-anchor="end">60%</text><text class="tick" x="82" y="320" text-anchor="middle">20 min</text><text class="tick" x="157" y="320" text-anchor="middle">1 hr</text><text class="tick" x="306" y="320" text-anchor="middle">9 hr</text><text class="tick" x="372.6" y="320" text-anchor="middle">1 day</text><text class="tick" x="419.6" y="320" text-anchor="middle">2 days</text><text class="tick" x="494.2" y="320" text-anchor="middle">6 days</text><text class="tick" x="605.7" y="320" text-anchor="middle">31 days</text><path class="ln s1" stroke="#2a78d6" d="M 71 31.9 L 83.9 41 L 96.9 49.6 L 109.8 57.8 L 122.8 65.6 L 135.7 72.9 L 148.7 80 L 161.6 86.6 L 174.6 93 L 187.5 99 L 200.5 104.8 L 213.5 110.3 L 226.4 115.5 L 239.4 120.5 L 252.3 125.3 L 265.3 129.9 L 278.2 134.3 L 291.2 138.5 L 304.1 142.5 L 317.1 146.3 L 330 150 L 343 153.6 L 356 157 L 368.9 160.2 L 381.9 163.4 L 394.8 166.4 L 407.8 169.3 L 420.7 172.1 L 433.7 174.8 L 446.6 177.4 L 459.6 179.9 L 472.5 182.3 L 485.5 184.7 L 498.5 187 L 511.4 189.1 L 524.4 191.2 L 537.3 193.3 L 550.3 195.3 L 563.2 197.2 L 576.2 199 L 589.1 200.8 L 602.1 202.6 L 615 204.3 L 628 205.9"/><path class="ln s2" stroke="#eb6834" d="M 82.2 84.5 L 156.8 129.7 L 306 174 L 372.6 155.2 L 419.6 195 L 494.2 223.3 L 605.7 281.3"/><circle class="dot s1" fill="#2a78d6" cx="82.2" cy="34.2" r="4.5"><title>20 min — Ebbinghaus 1885: 58.2% saved</title></circle><circle class="dot s1" fill="#2a78d6" cx="156.8" cy="98.2" r="4.5"><title>1 hr — Ebbinghaus 1885: 44.2% saved</title></circle><circle class="dot s1" fill="#2a78d6" cx="306" cy="136.5" r="4.5"><title>9 hr — Ebbinghaus 1885: 35.8% saved</title></circle><circle class="dot s1" fill="#2a78d6" cx="372.6" cy="146.1" r="4.5"><title>1 day — Ebbinghaus 1885: 33.7% saved</title></circle><circle class="dot s1" fill="#2a78d6" cx="419.6" cy="173.1" r="4.5"><title>2 days — Ebbinghaus 1885: 27.8% saved</title></circle><circle class="dot s1" fill="#2a78d6" cx="494.2" cy="184" r="4.5"><title>6 days — Ebbinghaus 1885: 25.4% saved</title></circle><circle class="dot s1" fill="#2a78d6" cx="605.7" cy="203.6" r="4.5"><title>31 days — Ebbinghaus 1885: 21.1% saved</title></circle><circle class="dot s2" fill="#eb6834" cx="82.2" cy="84.5" r="4.5"><title>20 min — Dros 2015: 47.2% saved</title></circle><circle class="dot s2" fill="#eb6834" cx="156.8" cy="129.7" r="4.5"><title>1 hr — Dros 2015: 37.3% saved</title></circle><circle class="dot s2" fill="#eb6834" cx="306" cy="174" r="4.5"><title>9 hr — Dros 2015: 27.6% saved</title></circle><circle class="dot s2" fill="#eb6834" cx="372.6" cy="155.2" r="4.5"><title>1 day — Dros 2015: 31.7% saved</title></circle><circle class="dot s2" fill="#eb6834" cx="419.6" cy="195" r="4.5"><title>2 days — Dros 2015: 23.0% saved</title></circle><circle class="dot s2" fill="#eb6834" cx="494.2" cy="223.3" r="4.5"><title>6 days — Dros 2015: 16.8% saved</title></circle><circle class="dot s2" fill="#eb6834" cx="605.7" cy="281.3" r="4.5"><title>31 days — Dros 2015: 4.1% saved</title></circle><text class="val" x="494.2" y="171" text-anchor="middle">25%</text><text class="val" x="494.2" y="241" text-anchor="middle">17%</text><line class="grid" x1="58" y1="350" x2="80" y2="350"/><path class="ln s1" stroke="#2a78d6" d="M 58 350 L 80 350"/><circle class="dot s1" fill="#2a78d6" cx="69" cy="350" r="4.5"/><text class="lgd" x="90" y="354.5">Ebbinghaus (1885) — his data points, and the curve he fit to them</text><path class="ln s2" stroke="#eb6834" d="M 58 374 L 80 374"/><circle class="dot s2" fill="#eb6834" cx="69" cy="374" r="4.5"/><text class="lgd" x="90" y="378.5">Murre &amp; Dros (2015) replication</text></svg><figcaption>Percentage of original learning time <em>saved</em> when relearning the same list, against time since learning (log scale). At six days, a quarter of the learning survives.</figcaption></figure>
+
 - Hence, to effectively retain what has been learned, it is necessary periodically revise it.
+
+> [!abstract]- Is the 80% number made up? — Ebbinghaus 1885, and its replication
+> **What the curve actually measures.** Ebbinghaus memorised lists of *nonsense syllables*, waited, then relearned the same list. The y-axis is not "how much can you recall" but **savings**: the fraction of the original learning time he no longer needed on the second pass. Savings and recall are not interchangeable — savings is the more forgiving measure, so a free-recall curve would sit lower still.
+>
+> **His fitted equation.** He described the decay with
+>
+> $$b(t) = \frac{100k}{(\log_{10} t)^{c} + k}, \qquad k = 1.84,\quad c = 1.25$$
+>
+> where $t$ is minutes elapsed and $b$ the percentage saved — the smooth blue line above. He gave no derivation for it, and cautioned that the constants "may find expression in other constants … under other circumstances". Modern models drop it for an exponential, $R = e^{-t/S}$, where $S$ is the memory's *stability*. That $S$ is precisely what a scheduler like FSRS estimates per card from your review history, which is why the curve isn't just history — it's the object being fit.
+>
+> **The replication.** Murre & Dros reran the whole thing 130 years later and recovered the shape, including the small upward bump around the 24-hour mark (a sleep effect — the curve is not perfectly smooth). Their tail falls much harder: 4% saved at 31 days against Ebbinghaus's 21%.
+>
+> | Interval | Ebbinghaus 1885 | Murre & Dros 2015 |
+> |---|---|---|
+> | 20 min | 58.2 | 47.2 |
+> | 1 hr | 44.2 | 37.3 |
+> | 9 hr | 35.8 | 27.6 |
+> | 1 day | 33.7 | 31.7 |
+> | 2 days | 27.8 | 23.0 |
+> | 6 days | 25.4 | 16.8 |
+> | 31 days | 21.1 | 4.1 |
+>
+> **The verdict.** At six days Ebbinghaus retained 25% and the replication 17% — 75–83% lost. So "80% in a week" is a fair reading of the source rather than an invention. The caveats are what matter: both are $n = 1$ self-experiments, and nonsense syllables are the least learnable material there is, chosen precisely to strip out meaning. Anything understood, or hooked into what you already know, decays far more slowly. Take the number as directional — the *shape* is the durable finding, not the constant.
+>
+> Savings values from Murre & Dros (2015), [Replication and Analysis of Ebbinghaus' Forgetting Curve](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0120644), *PLOS ONE* 10(7): e0120644, Table 3.
 
 ### Why spaced repetition?
 - Growing up, revision involved re-reading the entire syllabus before an exam. The revision of chapters would start from the least recently learned chapter to the most recent one. I repeated this until the paper was in front of me on exam day. 
@@ -65,7 +92,7 @@ tags:
 >
 > - **First attempt.** I answered $O(V)$ — reasoning "we visit every node once". Wrong.
 > - **Edit: 1 a nudge on the front.** I added a prompt: *"Think of the exact operation on the data structure that 'visiting a node' translates to."* That pushed me past counting nodes to counting edges, and I landed on $O(V + E)$.
-> - **The gap ** We loop over $V$ vertices, and each one walks its edges — so why isn't it $O(V \cdot E)$? I couldn't resolve the multiplication into a sum.
+> - **The gap** We loop over $V$ vertices, and each one walks its edges — so why isn't it $O(V \cdot E)$? I couldn't resolve the multiplication into a sum.
 > - **Edit 2: the derivation on the back.** Writing the sum out cracked it. The work per vertex is $\deg_{out}(u)$, *not* $E$. Summed over all vertices, every edge is counted exactly once (it has a single source), so the counts collapse to $E$, never $V \cdot E$. Each edit didn't just fix the answer — it left me understanding *why*.
 >
 >
@@ -106,7 +133,7 @@ tags:
 
 
 ### Read More
-Great Primers
+Recom \
 https://augmentingcognition.com/ltm \
 https://www.justinmath.com/learning-is-memory/ \
 https://gwern.net/spaced-repetition \


### PR DESCRIPTION
@
The Anki note carried an unsourced line — *"Approximately, 80% of what you learn today will be forgotten by the next week"* — annotated `(is this number made up)`, plus an `Ebbinghaus_forgetting_curves.jpg` placeholder that was never filled in.

## Is it made up?

No, but it was under-qualified. Tracing it to source:

| | Ebbinghaus 1885 | Murre & Dros 2015 |
|---|---|---|
| 6 days | 25.4% saved | 16.8% saved |

So 75–83% lost at the one-week mark — "80%" is a fair reading. The caveats are what the popular version drops: both are n=1 self-experiments, the material is nonsense syllables (chosen precisely to strip out meaning), and the y-axis is *savings* — relearning time no longer needed — not free recall. Meaningful material decays far more slowly. The note now frames it as directional, with the shape as the durable finding rather than the constant.

## Changes

- Replaced the `.jpg` placeholder with an **inline SVG** plotting both series on a log time axis (20 min → 31 days): Ebbinghaus's data points sitting on the curve he fit to them, the replication overlaid. The 6-day pair is direct-labelled since it's the claim under test; dots carry `<title>` tooltips.
- Folded the derivation into a collapsible `[!abstract]` callout matching the note's existing style — his fitted equation in KaTeX, the pivot to $R = e^{-t/S}$ and how FSRS estimates that stability per card, the 24-hour sleep bump, and the full source table.
- Also sweeps up two in-progress edits to the same file: the Skycak attribution in the quote callout, and a stray space in `**The gap **`.

Source: Murre & Dros (2015), [Replication and Analysis of Ebbinghaus' Forgetting Curve](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0120644), *PLOS ONE* 10(7): e0120644, Table 3.

## Notes

Verified with a local `quartz build` — the figure, the KaTeX, and the callout all render. Dark-mode selectors are written unquoted (`[saved-theme=dark]`) because Quartz HTML-escapes quotes inside a `<style>` block in markdown; the quoted form built fine but silently broke the rule. Series colours are stepped separately for light and dark against the theme surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@