### PR TITLE
Unpublish three posts as drafts

### DIFF
--- a/content/notes/2026-05-03-NPUs-Are-the-Answer-to-the-Wrong-Problem.md
+++ b/content/notes/2026-05-03-NPUs-Are-the-Answer-to-the-Wrong-Problem.md
@@ -1,6 +1,7 @@
 ---
 title: "NPUs Are the Answer to the Wrong Problem"
 date: 2026-05-03
+draft: true
 assisted: prose
 assistedNote: "The hardware, the benchmarks and the conclusions are mine, from my own testing notes. An LLM drafted the prose from them."
 tags:

--- a/content/notes/2026-05-17-MTBF-MTTR-Vibe-Coding.md
+++ b/content/notes/2026-05-17-MTBF-MTTR-Vibe-Coding.md
@@ -1,6 +1,7 @@
 ---
 title: "MTBF, MTTR, and Vibe Coding"
 date: 2026-05-17
+draft: true
 tags:
     - miscellaneous
 ---

--- a/content/notes/jobProfileAutomation.md
+++ b/content/notes/jobProfileAutomation.md
@@ -1,6 +1,7 @@
 ---
 title: "Automating Job board Profile Updates"
 date: 2025-10-23
+draft: true
 assisted: prose
 assistedNote: "The project is mine. An LLM expanded my README into this write-up."
 tags:


### PR DESCRIPTION
Marks three posts `draft: true` so they stop being published.

- MTBF, MTTR, and Vibe Coding
- NPUs Are the Answer to the Wrong Problem
- Automating Job board Profile Updates

`RemoveDrafts` is already active in `quartz.config.ts:76`, so these emit no HTML and drop out of the search index and the graph. Build confirms `Filtered out 3 files`, 149 pages emitted instead of 152.

Nothing links to any of the three, so no links break.

The AI-assistance frontmatter added in #41 stays on two of them — moot while they're hidden, correct again if they're ever republished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)