### PR TITLE
Document deploy path, content conventions and disclosure fields in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Architecture notes for working in this Quartz (v4.5.1) repo.
 
 ## What this is
 
-Quartz is a **static site generator**: it compiles the Markdown vault in [content/](content/) into static HTML/CSS/JS at build time. There is no server runtime and no client-side framework shipped — output is plain static files, deployed to `ayush111111.github.io` ([quartz.config.ts:19](quartz.config.ts#L19)).
+Quartz is a **static site generator**: it compiles the Markdown vault in [content/](content/) into static HTML/CSS/JS at build time. There is no server runtime and no client-side framework shipped — output is plain static files, published at **https://ayush111111.github.io/quartz/** (see [Deploying](#deploying) for the path caveat).
 
 ## Component model
 
@@ -37,6 +37,43 @@ Interactivity (search, graph, dark mode, popovers, SPA nav, etc.) is **not** Pre
 - `transformers/` — markdown/AST processing, one file per concern: `ofm.ts` (Obsidian compat), `gfm.ts`, `syntax.ts`, `toc.ts`, `links.ts`, `latex.ts`, `citations.ts`, `lastmod.ts`, `frontmatter.ts`, `description.ts`, `roam.ts`, `oxhugofm.ts`, `linebreaks.ts`
 - `filters/` — decide what gets published at all: `draft.ts`, `explicit.ts`
 - `emitters/` — decide what gets written to disk: `contentPage.tsx`, `folderPage.tsx`, `tagPage.tsx`, `contentIndex.tsx`, `aliases.ts`, `assets.ts`, `static.ts`, `favicon.ts`, `componentResources.ts`, `404.tsx`, `cname.ts`, `ogImage.tsx`
+
+## Deploying
+
+This is a GitHub Pages **project** site, so it is served from a `/quartz/` path prefix:
+
+```
+https://ayush111111.github.io/quartz/notes/<slug>
+```
+
+`baseUrl` at [quartz.config.ts:19](quartz.config.ts#L19) is the bare host with **no** path, so it does not match the live URL. Building a live URL from `baseUrl` alone produces a 404.
+
+When verifying something on the live site, **always fetch a known-published page as a control in the same check**. A wrong path prefix 404s every URL, which is indistinguishable from a page having been successfully removed. This has already caused one false "confirmed removed" report.
+
+Publishing flow: branch off `v4` → PR → merge to `v4`. [.github/workflows/deploy.yml](.github/workflows/deploy.yml) triggers on push to `v4` and takes about a minute. A change is not live until that run completes; pushing a branch or opening a PR does nothing on its own.
+
+## Content conventions
+
+Posts live in [content/notes/](content/notes/) (dated, usually `YYYY-MM-DD-Title.md`) and [content/misc/](content/misc/) (essays, undated names). [content/index.md](content/index.md) is the About page.
+
+Frontmatter fields beyond the Quartz defaults, declared in the `DataMap` block at the bottom of [quartz/plugins/transformers/frontmatter.ts](quartz/plugins/transformers/frontmatter.ts) and rendered by [quartz/components/ContentMeta.tsx](quartz/components/ContentMeta.tsx):
+
+| Field | Effect |
+|---|---|
+| `draft: true` | Unpublishes the note entirely. `RemoveDrafts` is active at [quartz.config.ts:76](quartz.config.ts#L76), so no HTML is emitted and the page drops out of the search index and graph. |
+| `assisted: prose \| summary` | AI-disclosure marker in the meta line. `prose` = an LLM wrote the prose from the author's material; `summary` = an LLM summarized source the author read. |
+| `assistedNote: "..."` | Hover text for the marker. Falls back to a per-kind default. Prefer a specific sentence about what the LLM actually did over the generic one. |
+| `written: YYYY-MM-DD` | For posts whose dateline refers to the period they describe rather than when they were composed. Renders as "written May 2026". Opt-in; only set where the gap is real. |
+
+Note that Quartz passes **arbitrary** frontmatter keys through to `fileData.frontmatter`, so adding a new field needs only a type declaration plus rendering, not a transformer change.
+
+Renaming a note changes its URL and silently breaks any existing link to it. Add the old path to `aliases:` when renaming.
+
+## Writing content
+
+Match the author's voice; do not "improve" it. When the author supplies text, reproduce it verbatim rather than polishing it. Avoid em dashes and other LLM-flavored phrasing in anything written for `content/`.
+
+Much of the existing prose in `content/notes/` was LLM-drafted and reads that way. Do not treat it as a style reference.
 
 ## Docs
 


### PR DESCRIPTION
Records operational knowledge that wasn't written down and cost real time this week.

**The deploy path.** This is a GitHub Pages *project* site, served from `https://ayush111111.github.io/quartz/`. `baseUrl` at `quartz.config.ts:19` is the bare host with no path, and AGENTS.md previously repeated that as the deploy target. Constructing a live URL from it 404s.

**The verification rule.** A wrong path prefix 404s every URL, which is indistinguishable from a page having been successfully unpublished. That produced one false "confirmed removed" report. Live checks now documented as requiring a known-published control page in the same pass.

**Publishing flow.** Branch off `v4` → PR → merge. `deploy.yml` fires on push to `v4`; nothing is live until that run finishes.

**Frontmatter fields.** Table covering `draft`, `assisted`, `assistedNote` and `written` — what each does, where it's declared (`frontmatter.ts` DataMap) and where it's rendered (`ContentMeta.tsx`). Plus the note that Quartz passes arbitrary keys through, so new fields need no transformer change.

**Voice.** Match the author; don't polish supplied text; avoid em dashes. Flags that existing `content/notes/` prose is largely LLM-drafted and shouldn't be used as a style reference.

Docs only — no effect on the built site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)