### PR TITLE
Add a projects tag to the four project write-ups

### DIFF
--- a/content/notes/2021-08-15-Formula-Manipal-Driverless-Perception.md
+++ b/content/notes/2021-08-15-Formula-Manipal-Driverless-Perception.md
@@ -5,6 +5,7 @@ written: 2026-05-25
 assisted: prose
 assistedNote: "Written in 2026 about work I did in 2020–21. The project, the findings and the source material are mine; an LLM drafted the prose from my old project files and notes."
 tags:
+    - projects
     - robotics
     - computer-vision
     - autonomous-systems

--- a/content/notes/2021-1-16-Hello-World.md
+++ b/content/notes/2021-1-16-Hello-World.md
@@ -2,6 +2,7 @@
 title: "PID Control line follower"
 date: 2021-01-16
 tags:
+  - projects
   - robotics
   - control-systems
   - computer-vision

--- a/content/notes/2021-11-01-Samsung-PRISM-Camera-Placement.md
+++ b/content/notes/2021-11-01-Samsung-PRISM-Camera-Placement.md
@@ -5,6 +5,7 @@ written: 2026-05-25
 assisted: prose
 assistedNote: "Written in 2026 about work I did in 2021. The project, the findings and the source material are mine; an LLM drafted the prose from my old project files and notes."
 tags:
+    - projects
     - computer-vision
     - geometry
     - internship

--- a/content/notes/2023-04-26-Automated-Head-Circumference-Measurement.md
+++ b/content/notes/2023-04-26-Automated-Head-Circumference-Measurement.md
@@ -2,6 +2,7 @@
 title: "Automated Head Circumference Measurement"
 date: 2023-04-26
 tags:
+  - projects
   - machine-learning
   - medical-imaging
   - computer-vision


### PR DESCRIPTION
Tags the four posts that document something actually built, so Quartz generates a browsable `/tags/projects` page.

| Post | Artifact |
|---|---|
| Building Perception for a Driverless Formula Car | Two years of perception pipeline work, competed and won |
| Samsung PRISM: Optimal Camera Placement | Research project with a concrete deliverable |
| Automated Head Circumference Measurement | Trained model, WandB runs, live Gradio app |
| PID Control line follower | Working two-controller system |

Build confirms `/tags/projects` lists exactly those four and nothing else. 151 files emitted, up from 149.

## Excluded

Lecture notes (the 12 Berkeley ones plus both MOOC-2 lectures), paper summaries, reference compilations (LLD2, LLDmd, dp203, spark, Bayesian, Anki) and everything in `misc/`.

`General Problem Solving Template` was considered and left out — it's a reference artifact rather than an engineering project, and including it would stretch the tag to mean "things I made," which starts pulling in unrelated notes.

`Automating Job board Profile Updates` qualifies on merit but is currently `draft: true`, so it's untagged for now.

## Note

This is a **type** tag, where the existing tags are topical. That's a deliberate departure — `internship` on the Samsung post is existing precedent for one. If this is worth systematising later, `projects` should probably replace `internship` there rather than sit beside it. Left alone in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)